### PR TITLE
chore(dependabot): add 7-day cooldown to all update blocks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,16 @@ updates:
     directory: "frontend/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ":robot:"
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "pocketbase/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ":robot:"
   # GitHub Actions
@@ -22,5 +26,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ":seedling:"


### PR DESCRIPTION
## What

Adds a 7-day cooldown (`cooldown: { default-days: 7 }`) to every `updates` block in `dependabot.yml`.

## Why

Most malicious package releases (typosquats, hijacked maintainers, malicious post-install) are detected and pulled within 24-72h. A 7-day cooldown keeps us out of that danger window for routine version bumps. **Security updates are exempt from cooldown**, so CVE fixes still land immediately.

7 days is the cross-tool consensus value (Dependabot / Renovate `minimumReleaseAge` / npm `min-release-age`). Part of an org-wide rollout across all repos using Dependabot.

> Note: for `gomod` / `github-actions` / `docker`, Dependabot keys cooldown off the git tag commit date rather than release date, so treat it as defense-in-depth rather than airtight. See dependabot/dependabot-core#13078.